### PR TITLE
Add custom Error class with test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in your *.gemspec file
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,45 @@
+PATH
+  remote: .
+  specs:
+    synapse_pay_rest (0.0.10)
+      rest-client
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ansi (1.5.0)
+    builder (3.2.2)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    mime-types (2.6.2)
+    minitest (5.8.2)
+    minitest-reporters (1.1.5)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    netrc (0.11.0)
+    rake (10.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    ruby-progressbar (1.7.5)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.10)
+  minitest
+  minitest-reporters
+  rake (~> 10.0)
+  synapse_pay_rest!
+
+BUNDLED WITH
+   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+task :default => :test

--- a/lib/synapse_pay_rest.rb
+++ b/lib/synapse_pay_rest.rb
@@ -1,5 +1,6 @@
 # Basic wrapper around the the requests library.
 require_relative "synapse_pay_rest/http_client"
+require_relative "synapse_pay_rest/error"
 # Assign all the api classes
 require_relative "synapse_pay_rest/api/Users"
 require_relative "synapse_pay_rest/api/Nodes"

--- a/lib/synapse_pay_rest/error.rb
+++ b/lib/synapse_pay_rest/error.rb
@@ -1,0 +1,114 @@
+module SynapsePayRest
+  class Error < StandardError
+    # Raised on a 4xx HTTP status code
+    ClientError = Class.new(self)
+
+    # Raised on the HTTP status code 400
+    BadRequest = Class.new(ClientError)
+
+    # Raised on the HTTP status code 401
+    Unauthorized = Class.new(ClientError)
+
+    # Raised on the HTTP status code 402
+    RequestDeclined = Class.new(ClientError)
+
+    # Raised on the HTTP status code 403
+    Forbidden = Class.new(ClientError)
+
+    # Raised on the HTTP status code 404
+    NotFound = Class.new(ClientError)
+
+    # Raised on the HTTP status code 406
+    NotAcceptable = Class.new(ClientError)
+
+    # Raised on the HTTP status code 409
+    Conflict = Class.new(ClientError)
+
+    # Raised on the HTTP status code 415
+    UnsupportedMediaType = Class.new(ClientError)
+
+    # Raised on the HTTP status code 422
+    UnprocessableEntity = Class.new(ClientError)
+
+    # Raised on the HTTP status code 429
+    TooManyRequests = Class.new(ClientError)
+
+    # Raised on a 5xx HTTP status code
+    ServerError = Class.new(self)
+
+    # Raised on the HTTP status code 500
+    InternalServerError = Class.new(ServerError)
+
+    # Raised on the HTTP status code 502
+    BadGateway = Class.new(ServerError)
+
+    # Raised on the HTTP status code 503
+    ServiceUnavailable = Class.new(ServerError)
+
+    # Raised on the HTTP status code 504
+    GatewayTimeout = Class.new(ServerError)
+
+    ERRORS = {
+      400 => SynapsePayRest::Error::BadRequest,
+      401 => SynapsePayRest::Error::Unauthorized,
+      402 => SynapsePayRest::Error::RequestDeclined,
+      403 => SynapsePayRest::Error::Forbidden,
+      404 => SynapsePayRest::Error::NotFound,
+      406 => SynapsePayRest::Error::NotAcceptable,
+      409 => SynapsePayRest::Error::Conflict,
+      415 => SynapsePayRest::Error::UnsupportedMediaType,
+      422 => SynapsePayRest::Error::UnprocessableEntity,
+      429 => SynapsePayRest::Error::TooManyRequests,
+      500 => SynapsePayRest::Error::InternalServerError,
+      502 => SynapsePayRest::Error::BadGateway,
+      503 => SynapsePayRest::Error::ServiceUnavailable,
+      504 => SynapsePayRest::Error::GatewayTimeout,
+    }
+
+    # The SynapsePay API Error Code
+    #
+    # @return [Integer]
+    attr_reader :code
+
+    # The JSON HTTP response in Hash form
+    #
+    # @return [Hash]
+    attr_reader :response
+
+    class << self
+      # Create a new error from an HTTP response
+      #
+      # @param body [String]
+      # @param code [Integer]
+      # @return [SynapsePayRest::Error]
+      def error_from_response(body, code)
+        klass = ERRORS[code] || SynapsePayRest::Error
+        message, error_code = parse_error(body)
+        klass.new(message: message, code: error_code, response: body)
+      end
+
+    private
+
+      def parse_error(body)
+        if body.nil? || body.empty?
+          ['', nil]
+        elsif body.is_a?(Hash) && body['error'].is_a?(Hash)
+          [body['error']['en'], body['error_code']]
+        end
+      end
+
+    end
+
+    # Initializes a new Error object
+    #
+    # @param message [Exception, String]
+    # @param code [Integer]
+    # @param response [Hash]
+    # @return [SynapsePayRest::Error]
+    def initialize(message: '', code: nil, response: {})
+      super(message)
+      @code = code
+      @response = response
+    end
+  end
+end

--- a/synapse_pay_rest.gemspec
+++ b/synapse_pay_rest.gemspec
@@ -9,9 +9,18 @@ Gem::Specification.new do |s|
   s.description = "A simple ruby wrapper for the SynapsePay v3 Rest API"
   s.authors     = ["Thomas Hipps"]
   s.email       = 'thomas@synapsepay.com'
-  s.require_paths = ["lib"]
-  s.files       = Dir.glob("{lib}/**/*")
   s.homepage    = 'https://rubygems.org/gems/synapse_pay_rest'
   s.license     = 'MIT'
+
+  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.bindir        = "exe"
+  s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  s.require_paths = ["lib"]
+
+  s.add_development_dependency "bundler", "~> 1.10"
+  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "minitest"
+  s.add_development_dependency "minitest-reporters"
+
   s.add_dependency "rest-client"
 end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ErrorTest < Minitest::Test
+
+  def test_400_error_code
+    response = {"error"=>{"en"=>"Unable to verify document information. Please submit a valid copy of passport/driver's license."}, "error_code"=>"400", "http_code"=>"409", "success"=>false}
+
+    error = SynapsePayRest::Error.error_from_response(response, 409)
+
+    assert_instance_of SynapsePayRest::Error::Conflict, error
+    assert_kind_of SynapsePayRest::Error::ClientError, error
+    assert_equal "Unable to verify document information. Please submit a valid copy of passport/driver's license.", error.message
+    assert_equal '400', error.code
+    assert_equal response, error.response
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,6 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'synapse_pay_rest'
+require 'minitest/autorun'
+require 'minitest/reporters'
+
+Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])


### PR DESCRIPTION
The gem needs to be have its own error class that can parse the
response and fail with so its easier for gem consumers to deal with
errors consistently. I’d add more but we need to make several changes
elsewhere. This is just the first phase. We should be merging (or modifying) in PR #2 to start
and building off that.