### PR TITLE
Post when verifying mfa

### DIFF
--- a/lib/synapse_pay_rest/api/nodes.rb
+++ b/lib/synapse_pay_rest/api/nodes.rb
@@ -27,7 +27,7 @@ module SynapsePayRest
 
     def verify(node_id: nil, payload: raise("payload is required"))
       path = create_node_path(node_id: node_id)
-      client.patch(path, payload)
+      client.post(path, payload)
     end
 
     def delete(node_id: raise("node_id is required"))


### PR DESCRIPTION
According to the [SynapsePay docs](https://docs.synapsepay.com/docs/add-ach-us-node) verifying needs to be a post, not a patch