### PR TITLE
Version 2.2.0

### DIFF
--- a/lib/synapse_pay_rest/api/nodes.rb
+++ b/lib/synapse_pay_rest/api/nodes.rb
@@ -17,7 +17,8 @@ module SynapsePayRest
     # Sends a GET request to /nodes endpoint. Queries a specific node_id if
     # node_id supplied, else queries all nodes. Returns the response.
     # 
-    # @param node_id [String] id of the node
+    # @param user_id [String]
+    # @param node_id [String,void]
     # @param page [String,Integer] (optional) response will default to 1
     # @param per_page [String,Integer] (optional) response will default to 20
     # @param type [String] (optional)
@@ -31,12 +32,12 @@ module SynapsePayRest
     # @todo should use CGI or RestClient's param builder instead of
     #   rolling our own, probably error-prone and untested
     #   https://github.com/rest-client/rest-client#usage-raw-url
-    def get(node_id: nil, **options)
+    def get(user_id:, node_id: nil, **options)
       params = VALID_QUERY_PARAMS.map do |p|
         options[p] ? "#{p}=#{options[p]}" : nil
       end.compact
 
-      path = create_node_path(node_id: node_id)
+      path = node_path(user_id: user_id, node_id: node_id)
       path += '?' + params.join('&') if params.any?
       client.get(path)
     end
@@ -44,6 +45,7 @@ module SynapsePayRest
     # Sends a POST request to /nodes endpoint, to create a new node for the
     # current user, and returns the response.
     # 
+    # @param user_id [String]
     # @param payload [Hash] format depends on node type 
     # @see https://docs.synapsepay.com/docs/node-resources payload structure
     # 
@@ -51,18 +53,18 @@ module SynapsePayRest
     # HTTP response from API
     # 
     # @return [Hash] API response
-    def post(payload:)
-      path = create_node_path
+    def post(user_id:, payload:)
+      path = node_path(user_id: user_id)
       client.post(path, payload)
     end
-
     # Alias for #post (legacy name)
     alias_method :add, :post
 
     # Sends a PATCH request to /nodes endpoint to update a node, and returns the
     # response. Only used to verify microdeposits for ACH-US nodes currently.
     # 
-    # @param node_id [String] id of the node
+    # @param user_id [String]
+    # @param node_id [String]
     # @param payload [Hash]
     # @see https://docs.synapsepay.com/docs/verify-micro-deposit payload structure
     # 
@@ -70,50 +72,52 @@ module SynapsePayRest
     # HTTP response from API
     # 
     # @return [Hash] API response
-    def patch(node_id:, payload:)
-      path = create_node_path(node_id: node_id)
-      @client.patch(path, payload)
+    def patch(user_id:, node_id:, payload:)
+      path = node_path(user_id: user_id, node_id: node_id)
+      client.patch(path, payload)
     end
 
     # Sends a DELETE request to /node endpoint to remove a node, and returns the response.
     # 
-    # @param node_id [String] id of the node
+    # @param user_id [String]
+    # @param node_id [String]
     # 
     # @raise [SynapsePayRest::Error] may return subclasses of error based on 
     # HTTP response from API
     # 
     # @return [Hash] API response
-    def delete(node_id:)
-      path = create_node_path(node_id: node_id)
+    def delete(user_id:, node_id:)
+      path = node_path(user_id: user_id, node_id: node_id)
       client.delete(path)
     end
 
     # Verifies microdeposits (via #patch) for a node if a node_id supplied, else
     # submits answers to bank login MFA questions (via #post).
     # 
-    # @param node_id [String] id of the node
+    # @param user_id [String]
+    # @param node_id [String,void]
     # @param payload [Hash] see #patch and #post for payload format
     # @deprecated Use #update for microdeposit verification or #post for MFA answers.
-    def verify(node_id: nil, payload:)
+    def verify(user_id:, node_id: nil, payload:)
       if node_id
         warn caller.first + " DEPRECATION WARNING: #{self.class}##{__method__} is deprecated. Use #patch instead."
 
         # verify microdeposits
-        patch(node_id: node_id, payload: payload)
+        patch(user_id: user_id, node_id: node_id, payload: payload)
       else
         warn caller.first + " DEPRECATION WARNING: #{self.class}##{__method__} is deprecated. Use #post instead."
 
         # verify MFA questions
-        post(payload: payload)
+        post(user_id: user_id, payload: payload)
       end
     end
 
     private
 
-    def create_node_path(node_id: nil)
-      path = ['/users', client.user_id, 'nodes' ]
-      path << node_id if node_id
-      path.join('/')
+    def node_path(user_id:, node_id: nil)
+      path = "/users/#{user_id}/nodes"
+      path += "/#{node_id}" if node_id
+      path
     end
   end
 end

--- a/lib/synapse_pay_rest/api/transactions.rb
+++ b/lib/synapse_pay_rest/api/transactions.rb
@@ -20,6 +20,7 @@ module SynapsePayRest
     # Sends a GET request to /trans endpoint. Queries a specific transaction_id
     # if trans_id supplied, else queries all transactions. Returns the response.
     # 
+    # @param user_id [String]
     # @param node_id [String] id of the from node
     # @param trans_id [String,void] (optional) id of a transaction to look up
     # @param page [String,Integer] (optional) response will default to 1
@@ -33,8 +34,8 @@ module SynapsePayRest
     # @todo Probably should use CGI or RestClient's param builder instead of
     # rolling our own, probably error-prone and untested version
     # https://github.com/rest-client/rest-client#usage-raw-url
-    def get(node_id:, trans_id: nil, **options)
-      path = create_transaction_path(node_id: node_id, trans_id: trans_id)
+    def get(user_id:, node_id:, trans_id: nil, **options)
+      path = create_transaction_path(user_id: user_id, node_id: node_id, trans_id: trans_id)
 
       params = VALID_QUERY_PARAMS.map do |p|
         options[p] ? "#{p}=#{options[p]}" : nil
@@ -47,6 +48,7 @@ module SynapsePayRest
     # Sends a POST request to /trans endpoint to create a new transaction.
     # Returns the response.
     # 
+    # @param user_id [String]
     # @param node_id [String] id of the from node
     # @param payload [Hash]
     # @see https://docs.synapsepay.com/docs/create-transaction payload structure
@@ -55,14 +57,15 @@ module SynapsePayRest
     # HTTP response from API
     # 
     # @return [Hash] API response
-    def create(node_id:, payload:)
-      path = create_transaction_path(node_id: node_id)
+    def create(user_id:, node_id:, payload:)
+      path = create_transaction_path(user_id: user_id, node_id: node_id)
       client.post(path, payload)
     end
 
     # Sends a PATCH request to /trans endpoint to update a transaction. 
     # Returns the response.
     # 
+    # @param user_id [String]
     # @param node_id [String] id of the from node
     # @param trans_id [String] id of a transaction to update
     # @param payload [Hash]
@@ -72,14 +75,15 @@ module SynapsePayRest
     # HTTP response from API
     # 
     # @return [Hash] API response
-    def update(node_id:, trans_id:, payload:)
-      path = create_transaction_path(node_id: node_id, trans_id: trans_id)
+    def update(user_id:, node_id:, trans_id:, payload:)
+      path = create_transaction_path(user_id: user_id, node_id: node_id, trans_id: trans_id)
       client.patch(path, payload)
     end
 
     # Sends a DELETE request to /trans endpoint to cancel a transaction.
     # Returns the response.
     # 
+    # @param user_id [String]
     # @param node_id [String] id of the from node
     # @param trans_id [String] id of a transaction to delete
     # 
@@ -87,17 +91,17 @@ module SynapsePayRest
     # HTTP response from API
     # 
     # @return [Hash] API response
-    def delete(node_id:, trans_id:)
-      path = create_transaction_path(node_id: node_id, trans_id: trans_id)
+    def delete(user_id:, node_id:, trans_id:)
+      path = create_transaction_path(user_id: user_id, node_id: node_id, trans_id: trans_id)
       client.delete(path)
     end
 
     private
 
-    def create_transaction_path(node_id:, trans_id: nil)
-      path = ['/users', client.user_id, 'nodes', node_id, 'trans' ]
-      path << trans_id if trans_id
-      return path.join('/')
+    def create_transaction_path(user_id:, node_id:, trans_id: nil)
+      path = "/users/#{user_id}/nodes/#{node_id}/trans"
+      path += "/#{trans_id}" if trans_id
+      path
     end
   end
 end

--- a/lib/synapse_pay_rest/client.rb
+++ b/lib/synapse_pay_rest/client.rb
@@ -22,12 +22,11 @@ module SynapsePayRest
     # @param client_secret [String] should be stored in environment variable
     # @param ip_address [String] user's IP address
     # @param fingerprint [String] a hashed value, either unique to user or static
-    # @param user_id [String] (optional)
     # @param development_mode [String] default true
     # @param logging [Boolean] (optional) logs to stdout when true
     # @param log_to [String] (optional) file path to log to file (logging must be true)
     def initialize(client_id:, client_secret:, ip_address:, fingerprint: nil,
-                   user_id: nil, development_mode: true, **options)
+                   development_mode: true, **options)
       base_url = if development_mode
                    'https://sandbox.synapsepay.com/api/3'
                  else
@@ -37,7 +36,6 @@ module SynapsePayRest
       @http_client  = HTTPClient.new(base_url: base_url,
                                      client_id: client_id,
                                      client_secret: client_secret,
-                                     user_id: user_id,
                                      fingerprint: fingerprint,
                                      ip_address: ip_address,
                                      **options)

--- a/lib/synapse_pay_rest/http_client.rb
+++ b/lib/synapse_pay_rest/http_client.rb
@@ -8,31 +8,29 @@ module SynapsePayRest
     #   @return [String] the base url of the API (production or sandbox)
     # @!attribute [rw] config
     #   @return [Hash] various settings related to request headers
-    # @!attribute [rw] user_id
-    #   @return [String] the user_id which is stored upon a call to Users#get or Users#create
-    attr_accessor :base_url, :config, :user_id
+    attr_accessor :base_url, :config
 
     # @param base_url [String] the base url of the API (production or sandbox)
     # @param client_id [String]
     # @param client_secret [String]
     # @param fingerprint [String]
     # @param ip_address [String]
-    # @param user_id [String] (optional) automatically stored on call to Users#get or Users#create
     # @param logging [Boolean] (optional) logs to stdout when true
     # @param log_to [String] (optional) file path to log to file (logging must be true)
-    def initialize(base_url:, client_id:, fingerprint:, ip_address:, client_secret:,
-                   user_id: nil, **options)
-
+    def initialize(base_url:, client_id:, fingerprint:, ip_address:,
+                   client_secret:, **options)
       log_to         = options[:log_to] || 'stdout'
       RestClient.log = log_to if options[:logging]
+      @logging = options[:logging]
 
       @config = {
-        fingerprint:   fingerprint,
         client_id:     client_id,
-        client_secret: client_secret
+        client_secret: client_secret,
+        fingerprint:   fingerprint,
+        ip_address:    ip_address,
+        oauth_key:     '',
       }
       @base_url = base_url
-      @user_id  = user_id
     end
 
     # Returns headers for HTTP requests.
@@ -52,9 +50,8 @@ module SynapsePayRest
     # Alias for #headers (legacy name)
     alias_method :get_headers, :headers
 
-    # Updates headers and/or user_id.
+    # Updates headers.
     # 
-    # @param user_id [String,void]
     # @param oauth_key [String,void]
     # @param fingerprint [String,void]
     # @param client_id [String,void]
@@ -62,11 +59,8 @@ module SynapsePayRest
     # @param ip_address [String,void]
     # 
     # @return [void]
-    # 
-    # @todo logic to update user_id doesn't belong here
-    def update_headers(user_id: nil, oauth_key: nil, fingerprint: nil,
-                       client_id: nil, client_secret: nil, ip_address: nil)
-      self.user_id           = user_id if user_id
+    def update_headers(oauth_key: nil, fingerprint: nil, client_id: nil,
+                       client_secret: nil, ip_address: nil, **options)
       config[:fingerprint]   = fingerprint if fingerprint
       config[:oauth_key]     = oauth_key if oauth_key
       config[:client_id]     = client_id if client_id
@@ -85,6 +79,7 @@ module SynapsePayRest
     # @return [Hash] API response
     def post(path, payload)
       response = with_error_handling { RestClient.post(full_url(path), payload.to_json, headers) }
+      p 'RESPONSE:', JSON.parse(response) if @logging
       JSON.parse(response)
     end
 
@@ -98,6 +93,7 @@ module SynapsePayRest
     # @return [Hash] API response
     def patch(path, payload)
       response = with_error_handling { RestClient.patch(full_url(path), payload.to_json, headers) }
+      p 'RESPONSE:', JSON.parse(response) if @logging
       JSON.parse(response)
     end
 
@@ -110,6 +106,7 @@ module SynapsePayRest
     # @return [Hash] API response
     def get(path)
       response = with_error_handling { RestClient.get(full_url(path), headers) }
+      p 'RESPONSE:', JSON.parse(response) if @logging
       JSON.parse(response)
     end
 
@@ -122,6 +119,7 @@ module SynapsePayRest
     # @return [Hash] API response
     def delete(path)
       response = with_error_handling { RestClient.delete(full_url(path), headers) }
+      p 'RESPONSE:', JSON.parse(response) if @logging
       JSON.parse(response)
     end
 

--- a/lib/synapse_pay_rest/models/node/ach_us_node.rb
+++ b/lib/synapse_pay_rest/models/node/ach_us_node.rb
@@ -25,7 +25,7 @@ module SynapsePayRest
 
         payload = payload_for_create_via_bank_login(bank_name: bank_name, username: username, password: password)
         user.authenticate
-        response = user.client.nodes.add(payload: payload)
+        response = user.client.nodes.add(user_id: user.id, payload: payload)
         # MFA questions
         if response['mfa']
           create_unverified_node(user, response)
@@ -89,7 +89,7 @@ module SynapsePayRest
       end
 
       payload = verify_microdeposits_payload(amount1: amount1, amount2: amount2)
-      response = user.client.nodes.patch(node_id: id, payload: payload)
+      response = user.client.nodes.patch(user_id: user.id, node_id: id, payload: payload)
       self.class.from_response(user, response)
     end
 

--- a/lib/synapse_pay_rest/models/node/base_node.rb
+++ b/lib/synapse_pay_rest/models/node/base_node.rb
@@ -39,7 +39,7 @@ module SynapsePayRest
 
         payload = payload_for_create(nickname: nickname, **options)
         user.authenticate
-        response = user.client.nodes.add(payload: payload)
+        response = user.client.nodes.add(user_id: user.id, payload: payload)
         from_response(user, response['nodes'].first)
       end
 
@@ -65,7 +65,12 @@ module SynapsePayRest
         end
         
         user.authenticate
-        response = user.client.nodes.get(page: page, per_page: per_page, type: self.type)
+        response = user.client.nodes.get(
+          user_id: user.id,
+          page: page,
+          per_page: per_page,
+          type: self.type
+        )
         multiple_from_response(user, response['nodes'])
       end
 
@@ -258,7 +263,7 @@ module SynapsePayRest
     # @return [:success]
     def deactivate
       user.authenticate
-      user.client.nodes.delete(node_id: id)
+      user.client.nodes.delete(user_id: user.id, node_id: id)
       :success
     end
 

--- a/lib/synapse_pay_rest/models/node/node.rb
+++ b/lib/synapse_pay_rest/models/node/node.rb
@@ -62,7 +62,12 @@ module SynapsePayRest
         end
 
         user.authenticate
-        response = user.client.nodes.get(page: page, per_page: per_page, type: type)
+        response = user.client.nodes.get(
+          user_id: user.id,
+          page: page,
+          per_page: per_page,
+          type: type
+        )
         multiple_from_response(user, response['nodes'])
       end
 

--- a/lib/synapse_pay_rest/models/node/synapse_np_node.rb
+++ b/lib/synapse_pay_rest/models/node/synapse_np_node.rb
@@ -1,5 +1,7 @@
 module SynapsePayRest
   # Represents a Synapse node allowing any user to hold Nepali Rupees.
+  # 
+  # @deprecated
   class SynapseNpNode < BaseNode
     class << self
       private

--- a/lib/synapse_pay_rest/models/node/triumph_subaccount_us_node.rb
+++ b/lib/synapse_pay_rest/models/node/triumph_subaccount_us_node.rb
@@ -1,6 +1,5 @@
 module SynapsePayRest
-  # Represents a Synapse node allowing any user to hold funds. You can use this
-  # node as a wallet, an escrow account or something else along those lines.
+  # Represents a subaccount inside a FBO account at Triumph Bank.
   class TriumphSubaccountUsNode < BaseNode
     class << self
       private

--- a/lib/synapse_pay_rest/models/node/triumph_subaccount_us_node.rb
+++ b/lib/synapse_pay_rest/models/node/triumph_subaccount_us_node.rb
@@ -1,5 +1,7 @@
 module SynapsePayRest
   # Represents a subaccount inside a FBO account at Triumph Bank.
+  # 
+  # @deprecated
   class TriumphSubaccountUsNode < BaseNode
     class << self
       private

--- a/lib/synapse_pay_rest/models/node/unverified_node.rb
+++ b/lib/synapse_pay_rest/models/node/unverified_node.rb
@@ -31,7 +31,7 @@ module SynapsePayRest
     # @todo make a new Error subclass for incorrect MFA
     def answer_mfa(answer)
       payload  = payload_for_answer_mfa(answer: answer)
-      response = user.client.nodes.post(payload: payload)
+      response = user.client.nodes.post(user_id: user.id, payload: payload)
       
       handle_answer_mfa_response(response)
     end

--- a/lib/synapse_pay_rest/models/transaction/transaction.rb
+++ b/lib/synapse_pay_rest/models/transaction/transaction.rb
@@ -8,7 +8,6 @@ module SynapsePayRest
   #   better to refactor this into a mixin altogether since this shouldn't be instantiated. 
   # @todo reduce duplicated logic between User/BaseNode/Transaction
   class Transaction
-
     # @!attribute [rw] node
     #   @return [SynapsePayRest::Node] the node to which the transaction belongs
     attr_reader :node, :id, :amount, :currency, :client_id, :client_name, :created_on,
@@ -53,7 +52,11 @@ module SynapsePayRest
         payload = payload_for_create(node: node, to_type: to_type, to_id: to_id,
           amount: amount, currency: currency, ip: ip, **options)
         node.user.authenticate
-        response = node.user.client.trans.create(node_id: node.id, payload: payload)
+        response = node.user.client.trans.create(
+          user_id: node.user.id,
+          node_id: node.id,
+          payload: payload
+        )
         from_response(node, response)
       end
 
@@ -71,7 +74,11 @@ module SynapsePayRest
         raise ArgumentError, 'id must be a String' unless id.is_a?(String)
 
         node.user.authenticate
-        response = node.user.client.trans.get(node_id: node.id, trans_id: id)
+        response = node.user.client.trans.get(
+          user_id: node.user.id,
+          node_id: node.id,
+          trans_id: id
+        )
         from_response(node, response)
       end
 
@@ -94,7 +101,12 @@ module SynapsePayRest
         end
 
         node.user.authenticate
-        response = node.user.client.trans.get(node_id: node.id, page: page, per_page: per_page)
+        response = node.user.client.trans.get(
+          user_id: node.user.id,
+          node_id: node.id,
+          page: page,
+          per_page: per_page
+        )
         multiple_from_response(node, response['trans'])
       end
 
@@ -190,7 +202,12 @@ module SynapsePayRest
     # @return [Array<SynapsePayRest::Transaction>] (self)
     def add_comment(comment)
       payload = {'comment': comment}
-      response = node.user.client.trans.update(node_id: node.id, trans_id: id, payload: payload)
+      response = node.user.client.trans.update(
+        user_id: node.user.id,
+        node_id: node.id,
+        trans_id: id,
+        payload: payload
+      )
       self.class.from_response(node, response['trans'])
     end
 
@@ -200,7 +217,11 @@ module SynapsePayRest
     # 
     # @return [Array<SynapsePayRest::Transaction>] (self)
     def cancel
-      response = node.user.client.trans.delete(node_id: node.id, trans_id: id)
+      response = node.user.client.trans.delete(
+        user_id: node.user.id,
+        node_id: node.id,
+        trans_id: id
+      )
       self.class.from_response(node, response)
     end
 

--- a/lib/synapse_pay_rest/models/user/base_document.rb
+++ b/lib/synapse_pay_rest/models/user/base_document.rb
@@ -165,7 +165,7 @@ module SynapsePayRest
     # @return [SynapsePayRest::BaseDocument] new instance with updated info (id will be different if email or phone changed)
     def submit
       user.authenticate
-      response = user.client.users.update(payload: payload_for_submit)
+      response = user.client.users.update(user_id: user.id, payload: payload_for_submit)
       @user    = User.from_response(user.client, response)
 
       if id
@@ -212,7 +212,7 @@ module SynapsePayRest
       end
       user.authenticate
       payload  = payload_for_update(changes)
-      response = user.client.users.update(payload: payload)
+      response = user.client.users.update(user_id: user.id, payload: payload)
       @user    = User.from_response(user.client, response)
 
       if id

--- a/lib/synapse_pay_rest/models/user/user.rb
+++ b/lib/synapse_pay_rest/models/user/user.rb
@@ -174,7 +174,6 @@ module SynapsePayRest
     #   to instantiate via API action.
     def initialize(**options)
       options.each { |key, value| instance_variable_set("@#{key}", value) }
-      @client.http_client.user_id = id
       @base_documents  ||= []
     end
 
@@ -203,7 +202,7 @@ module SynapsePayRest
           read_only, phone_number, legal_name, remove_phone_number, remove_login'
       end
       authenticate
-      response = client.users.update(payload: payload_for_update(options))
+      response = client.users.update(user_id: id, payload: payload_for_update(options))
       # return an updated user instance
       self.class.from_response(client, response)
     end
@@ -308,7 +307,7 @@ module SynapsePayRest
     # 
     # @return [SynapsePayRest::User] (self)
     def authenticate
-      client.users.refresh(payload: payload_for_refresh)
+      client.users.refresh(user_id: id, payload: payload_for_refresh)
       self
     end
 
@@ -342,7 +341,7 @@ module SynapsePayRest
 
       payload = payload_for_refresh
       payload['phone_number'] = device
-      client.users.refresh(payload: payload)
+      client.users.refresh(user_id: id, payload: payload)
       :success
     end
 
@@ -362,7 +361,7 @@ module SynapsePayRest
       payload = payload_for_refresh
       payload['phone_number']   = device
       payload['validation_pin'] = pin
-      client.users.refresh(payload: payload)
+      client.users.refresh(user_id: id, payload: payload)
       :success
     end
 

--- a/lib/synapse_pay_rest/models/user/virtual_document.rb
+++ b/lib/synapse_pay_rest/models/user/virtual_document.rb
@@ -30,7 +30,7 @@ module SynapsePayRest
     # @todo should raise error if any questions aren't answered yet.
     def submit_kba
       user     = base_document.user
-      response = user.client.users.update(payload: payload_for_kba)
+      response = user.client.users.update(user_id: user.id, payload: payload_for_kba)
       user     = User.from_response(user.client, response)
       base_doc = user.base_documents.find { |doc| doc.id == base_document.id }
       ssn_doc  = base_doc.virtual_documents.find { |doc| doc.id == id }

--- a/lib/synapse_pay_rest/version.rb
+++ b/lib/synapse_pay_rest/version.rb
@@ -1,4 +1,4 @@
 module SynapsePayRest
-  # gem version
-  VERSION = '2.1.0'.freeze
+  # gem version:
+  VERSION = '2.2.0'.freeze
 end

--- a/test/api/nodes_test.rb
+++ b/test/api/nodes_test.rb
@@ -2,12 +2,16 @@ require 'test_helper'
 
 class NodesTest < Minitest::Test
   def setup
-    @client = test_client_with_user
-    @user   = refresh_user(@client, @client.client.user_id)
+    test_values = test_client_with_user
+    @client = test_values[:client]
+    @user   = test_values[:user]
   end
 
   def test_nodes_add_with_bank_login_no_mfa
-    response = @client.nodes.add(payload: test_ach_us_login_no_mfa_payload)
+    response = @client.nodes.add(
+      user_id: @user['_id'],
+      payload: test_ach_us_login_no_mfa_payload
+    )
 
     assert_equal response['http_code'], '200'
     assert_equal response['error_code'], '0'
@@ -15,14 +19,20 @@ class NodesTest < Minitest::Test
   end
 
   def test_nodes_add_with_bank_login_and_verify_mfa_questions
-    add_response = @client.nodes.add(payload: test_ach_us_login_with_mfa_payload)
+    add_response = @client.nodes.add(
+      user_id: @user['_id'],
+      payload: test_ach_us_login_with_mfa_payload
+    )
 
     assert_equal add_response['http_code'], '202'
     assert_equal add_response['error_code'], '10'
     refute_nil add_response['mfa']
 
     access_token = add_response['mfa']['access_token']
-    mfa_response = @client.nodes.verify(payload: test_mfa_payload(access_token: access_token))
+    mfa_response = @client.nodes.verify(
+      user_id: @user['_id'],
+      payload: test_mfa_payload(access_token: access_token)
+    )
 
     assert_equal mfa_response['http_code'], '200'
     assert_equal mfa_response['error_code'], '0'
@@ -30,13 +40,17 @@ class NodesTest < Minitest::Test
   end
 
   def test_nodes_add_with_account_and_routing_and_verify_with_correct_microdeposits
-    add_response = @client.nodes.add(payload: test_ach_us_manual_payload)
+    add_response = @client.nodes.add(
+      user_id: @user['_id'],
+      payload: test_ach_us_manual_payload
+    )
 
     assert_equal add_response['http_code'], '200'
     assert_equal add_response['error_code'], '0'
 
     node_id = add_response['nodes'][0]['_id']
     microdeposit_response = @client.nodes.verify(
+      user_id: @user['_id'],
       node_id: node_id,
       payload: test_microdeposit_payload
     )
@@ -45,8 +59,10 @@ class NodesTest < Minitest::Test
   end
 
   def test_nodes_get
-    client = test_client_with_node
-    response = client.nodes.get
+    test_values = test_client_with_node
+    client = test_values[:client]
+    user = test_values[:user]
+    response = client.nodes.get(user_id: user['_id'])
 
     assert_equal response['http_code'], '200'
     assert_equal response['error_code'], '0'
@@ -55,28 +71,31 @@ class NodesTest < Minitest::Test
   end
 
   def test_nodes_get_with_node_id
-    client = test_client_with_node
-    nodes_response = client.nodes.get
-    node_id = nodes_response['nodes'].first['_id']
-    node_response = client.nodes.get(node_id: node_id)
+    test_values    = test_client_with_node
+    client         = test_values[:client]
+    user           = test_values[:user]
+    nodes_response = client.nodes.get(user_id: user['_id'])
+    node_id        = nodes_response['nodes'].first['_id']
+    node_response  = client.nodes.get(user_id: user['_id'], node_id: node_id)
 
     assert_equal node_response['_id'], node_id
     assert_nil node_response['error']
   end
 
   def test_nodes_delete
-    client = test_client_with_node
-    nodes_response = client.nodes.get
-
-    node_id = nodes_response['nodes'].first['_id']
-    delete_response = client.nodes.delete(node_id: node_id)
+    test_values     = test_client_with_node
+    client          = test_values[:client]
+    user            = test_values[:user]
+    nodes_response  = client.nodes.get(user_id: user['_id'])
+    node_id         = nodes_response['nodes'].first['_id']
+    delete_response = client.nodes.delete(user_id: user['_id'], node_id: node_id)
 
     assert_equal delete_response['http_code'], '200'
     assert_equal delete_response['error_code'], '0'
 
     # verify node deleted
     assert_raises SynapsePayRest::Error::NotFound do
-      client.nodes.get(node_id: node_id)
+      client.nodes.get(user_id: user['_id'], node_id: node_id)
     end
   end
 end

--- a/test/api/users_test.rb
+++ b/test/api/users_test.rb
@@ -2,8 +2,9 @@ require 'test_helper'
 
 class UsersTest < Minitest::Test
   def setup
-    @client = test_client_with_user
-    @user   = refresh_user(@client, @client.client.user_id)
+    test_values = test_client_with_user
+    @client     = test_values[:client]
+    @user       = test_values[:user]
   end
 
   def test_users_create
@@ -30,7 +31,7 @@ class UsersTest < Minitest::Test
   end
 
   def test_users_get_with_query
-    response = @client.users.get(query: 'Doe')
+    response = @client.users.get(query: 'Selena')
 
     assert_equal '200', response['http_code']
     assert_equal '0', response['error_code']
@@ -38,30 +39,39 @@ class UsersTest < Minitest::Test
   end
 
   def test_users_get_with_user_id
-    response = @client.users.get(user_id: @client.client.user_id)
+    response = @client.users.get(user_id: @user['_id'])
     refute_nil response['_id']
   end
 
   def test_users_update
     payload = test_users_update_payload(refresh_token: @user['refresh_token'])
-    response = @client.users.update(payload: payload)
+    response = @client.users.update(user_id: @user['_id'], payload: payload)
     refute_nil response['_id']
   end
 
   def test_add_doc_kyc1_successful
-    response = @client.users.add_doc(payload: test_add_doc_kyc1_payload(document_value: '2222'))
+    payload = test_add_doc_kyc1_payload(document_value: '2222')
+    response = @client.users.add_doc(user_id: @user['_id'], payload: payload)
 
     refute_nil response['_id']
   end
 
   def test_add_doc_kyc1_with_correct_answer_kba
-    add_doc_response = @client.users.add_doc(payload: test_add_doc_kyc1_payload(document_value: '3333'))
+    payload = test_add_doc_kyc1_payload(document_value: '3333')
+    add_doc_response = @client.users.add_doc(
+      user_id: @user['_id'],
+      payload: payload
+    )
 
     assert_equal add_doc_response['error_code'], '10'
     assert_equal add_doc_response['http_code'], '202'
 
     question_set_id = add_doc_response['question_set']['id']
-    kba_response = @client.users.answer_kba(payload: test_kba_kyc1_payload(question_set_id: question_set_id))
+    payload = test_kba_kyc1_payload(question_set_id: question_set_id)
+    kba_response = @client.users.answer_kba(
+      user_id: @user['_id'],
+      payload: payload
+    )
     ssn_field = kba_response['documents'][0]['virtual_docs'].find do |doc|
       doc['document_type'] == 'SSN'
     end
@@ -70,12 +80,18 @@ class UsersTest < Minitest::Test
   end
 
   def test_attach_file_kyc1
-    response = @client.users.attach_file(file_path: fixture_path('id.png'))
+    response = @client.users.attach_file(
+      user_id: @user['_id'],
+      file_path: fixture_path('id.png')
+    )
     refute_nil response['_id']
   end
 
   def test_add_documents_via_kyc2
-    response = @client.users.update(payload: test_add_documents_kyc2_payload)
+    response = @client.users.update(
+      user_id: @user['_id'],
+      payload: test_add_documents_kyc2_payload
+    )
     base_document = response['documents'].last
 
     assert_operator base_document.length, :>=, 4
@@ -85,7 +101,10 @@ class UsersTest < Minitest::Test
   end
 
   def test_add_documents_via_kyc2_with_kba
-    add_docs_response = @client.users.update(payload: test_add_documents_kyc2_payload(virtual_docs: [test_kba_ssn_hash]))
+    add_docs_response = @client.users.update(
+      user_id: @user['_id'],
+      payload: test_add_documents_kyc2_payload(virtual_docs: [test_kba_ssn_hash])
+    )
     base_document = add_docs_response['documents'].last
 
     assert_operator base_document.length, :>=, 4
@@ -96,8 +115,14 @@ class UsersTest < Minitest::Test
     ssn = base_document['virtual_docs'].find { |doc| doc['document_type'] == 'SSN' && doc['status'] == 'SUBMITTED|MFA_PENDING'}
     assert_equal 'SUBMITTED|MFA_PENDING', ssn['status']
 
-    kba_payload = test_kba_kyc_2_payload(base_document_id: base_document['id'], document_id: ssn['id'])
-    kba_response = @client.users.update(payload: kba_payload)
+    kba_payload = test_kba_kyc_2_payload(
+      base_document_id: base_document['id'],
+      document_id: ssn['id']
+    )
+    kba_response = @client.users.update(
+      user_id: @user['_id'],
+      payload: kba_payload
+    )
     validated_ssn = kba_response['documents'].last['virtual_docs'].find { |doc| doc['id'] == ssn['id']}
 
     assert_equal 'SUBMITTED|VALID', validated_ssn['status']

--- a/test/factories/client.rb
+++ b/test/factories/client.rb
@@ -1,8 +1,7 @@
-def test_client(client_id: ENV.fetch('CLIENT_ID'),
-                client_secret: ENV.fetch('CLIENT_SECRET'),
+def test_client(client_id: ENV.fetch('TEST_CLIENT_ID'),
+                client_secret: ENV.fetch('TEST_CLIENT_SECRET'),
                 fingerprint: 'test_fp',
                 ip_address: '127.0.0.1',
-                user_id: nil,
                 development_mode: true,
                 logging: false,
                 log_to: nil)
@@ -11,7 +10,6 @@ def test_client(client_id: ENV.fetch('CLIENT_ID'),
     client_id: client_id,
     client_secret: client_secret,
     development_mode: development_mode,
-    user_id: user_id,
     fingerprint: fingerprint,
     ip_address: ip_address,
     logging: logging,
@@ -20,42 +18,68 @@ def test_client(client_id: ENV.fetch('CLIENT_ID'),
 end
 
 def test_client_with_user(**options)
-  user_response = test_client.users.create(payload: test_users_create_payload)
-  test_client(user_id: user_response['_id'], **options)
+  client = test_client(options)
+  user = client.users.create(payload: test_users_create_payload)
+  refresh_user(client, user['_id'])
+  {client: client, user: user}
 end
 
 def test_client_with_two_users(**options)
-  user_response1 = test_client(**options).users.create(payload: test_users_create_payload)
-  user_response2 = test_client(**options).users.create(payload: test_users_create_payload)
-  test_client(**options, user_id: user_response1['_id'])
+  client1 = test_client(**options)
+  user1 = client1.users.create(payload: test_users_create_payload)
+  refresh_user(client1, user1['_id'])
+  client2 = test_client(**options)
+  user2 = client2.users.create(payload: test_users_create_payload)
+  refresh_user(client2, user2['_id'])
+  {clients: [client1, client2], users: [user1, user2]}
 end
 
 def test_client_with_node
-  client = test_client_with_user
-  refresh_user(client, client.client.user_id)
-  client.nodes.add(payload: test_ach_us_login_no_mfa_payload)
-  client
+  test_values = test_client_with_user
+  client = test_values[:client]
+  user = test_values[:user]
+  nodes = client.nodes.add(
+    user_id: user['_id'],
+    payload: test_ach_us_login_no_mfa_payload
+  )['nodes']
+  {client: client, user: user, node: nodes.first}
 end
 
 def test_client_with_two_nodes
-  client = test_client_with_user
-  refresh_user(client, client.client.user_id)
-  client.nodes.add(payload: test_ach_us_login_no_mfa_payload)
-  client.nodes.add(payload: test_synapse_us_payload)
-  client
+  test_values = test_client_with_user
+  client = test_values[:client]
+  user = test_values[:user]
+  nodes = client.nodes.add(
+    user_id: user['_id'],
+    payload: test_ach_us_login_no_mfa_payload
+  )['nodes']
+  nodes.push(*client.nodes.add(
+    user_id: user['_id'],
+    payload: test_synapse_us_payload
+  )['nodes'])
+  {client: client, user: user, nodes: nodes}
 end
 
 def test_client_with_two_transactions
-  client    = test_client_with_two_nodes
-  nodes     = client.nodes.get['nodes']
-  from      = nodes.first
-  to        = nodes.last
+  test_values = test_client_with_two_nodes
+  client    = test_values[:client]
+  user      = test_values[:user]
+  nodes     = test_values[:nodes]
+  from      = nodes[0]
+  to        = nodes[1]
   payload1  = test_transaction_payload(from_id: from['_id'], from_type: from['type'],
                                        to_id: to['_id'], to_type: to['type'])
   payload2  = test_transaction_payload(from_id: from['_id'], from_type: from['type'],
                                        to_id: to['_id'], to_type: to['type'])
-
-  client.trans.create(node_id: from['_id'], payload: payload1)
-  client.trans.create(node_id: from['_id'], payload: payload2)
-  client
+  trans1 = client.trans.create(
+    user_id: user['_id'],
+    node_id: from['_id'],
+    payload: payload1
+  )
+  trans2 = client.trans.create(
+    user_id: user['_id'],
+    node_id: from['_id'],
+    payload: payload2
+  )
+  {client: client, user: user, nodes: nodes, transactions: [trans1, trans2]}
 end

--- a/test/factories/users_payloads.rb
+++ b/test/factories/users_payloads.rb
@@ -87,7 +87,7 @@ def test_add_doc_kyc1_payload(birth_day: rand(1..28),
                                    name_last: Faker::Name.last_name,
                                    address_street1: Faker::Address.street_address,
                                    address_postal_code: Faker::Address.zip,
-                                   address_country_code: Faker::Address.country_code,
+                                   address_country_code: 'US',
                                    document_value: '2222',
                                    document_type: 'SSN')
   {

--- a/test/model/transaction_test.rb
+++ b/test/model/transaction_test.rb
@@ -160,7 +160,8 @@ class TransactionTest < Minitest::Test
 
     # verify comment added in api
     response = @user.client.transactions.get(
-      node_id: @from_node.id,
+      user_id:  @user.id,
+      node_id:  @from_node.id,
       trans_id: transaction.id
     )
     assert_includes response['recent_status']['note'], 'testing 1 2 3'

--- a/test/model/user_test.rb
+++ b/test/model/user_test.rb
@@ -107,12 +107,12 @@ class UserTest < Minitest::Test
   end
 
   def test_search_with_page_and_per_page
-    query = 'test'
-    page1 = SynapsePayRest::User.search(client: test_client, query: query, page: 2, per_page: 5)
-    assert_equal 5, page1.length
+    query = '.com'
+    page1 = SynapsePayRest::User.search(client: test_client, query: query, page: 2, per_page: 3)
+    assert_equal 3, page1.length
 
-    page2 = SynapsePayRest::User.search(client: test_client, query: query, page: 3, per_page: 5)
-    assert_equal 5, page2.length
+    page2 = SynapsePayRest::User.search(client: test_client, query: query, page: 3, per_page: 2)
+    assert_equal 2, page2.length
     refute_equal page1.first.id, page2.first.id
   end
 

--- a/test/synapse_pay_rest/client_test.rb
+++ b/test/synapse_pay_rest/client_test.rb
@@ -15,7 +15,7 @@ class ClientTest < Minitest::Test
     client = SynapsePayRest::Client.new(@options)
     # these keys don't exist in config
     @options.delete(:development_mode)
-    @options.delete(:ip_address)
+    @options[:oauth_key] = ''
     assert_equal client.client.config, @options
     assert_equal client.client.config, @options
     assert_equal client.client.base_url, 'https://sandbox.synapsepay.com/api/3'

--- a/test/synapse_pay_rest/http_client_test.rb
+++ b/test/synapse_pay_rest/http_client_test.rb
@@ -2,9 +2,8 @@ require 'test_helper'
 
 class HTTPClientTest < Minitest::Test
   def setup
-    @client = test_client_with_user
-    refresh_user(@client, @client.client.user_id)
-    @http_client = @client.client
+    @client = test_client
+    @http_client = @client.http_client
   end
 
   def test_base_url
@@ -27,7 +26,6 @@ class HTTPClientTest < Minitest::Test
 
   def test_update_headers
     new_options = {
-      user_id:       'new user_id',
       fingerprint:   'new fingerprint',
       client_id:     'new client_id',
       client_secret: 'new client_secret',
@@ -37,7 +35,6 @@ class HTTPClientTest < Minitest::Test
     @http_client.update_headers(new_options)
     config = @http_client.config
 
-    assert_equal @http_client.user_id, new_options[:user_id]
     assert_equal config[:fingerprint], new_options[:fingerprint]
     assert_equal config[:client_id], new_options[:client_id]
     assert_equal config[:client_secret], new_options[:client_secret]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,6 +24,6 @@ end
 
 def refresh_user(client, user_id)
   user = client.users.get(user_id: user_id)
-  client.users.refresh(payload: {'refresh_token' => user['refresh_token']})
+  client.users.refresh(user_id: user_id, payload: {'refresh_token' => user['refresh_token']})
   user
 end


### PR DESCRIPTION
Reworks the library client object to be more stateless. This should fix the rare oauth refresh issues. 

If you're using the API payload interface (Users/Nodes/Trans/Transactions classes):
- user_id is now required for all Nodes method calls
- user_id is now required for Users#refresh
- node_id is now required for all Trans/Transactions method calls

If you're using the native interface (User, Node, Transaction, BaseDocument, etc.), everything should work the same.