### PR TITLE
2.2.3 - fix broken 2.2.2 endpoints

### DIFF
--- a/lib/synapse_pay_rest/version.rb
+++ b/lib/synapse_pay_rest/version.rb
@@ -1,4 +1,4 @@
 module SynapsePayRest
   # gem version:
-  VERSION = '2.2.2'.freeze
+  VERSION = '2.2.3'.freeze
 end


### PR DESCRIPTION
2.2.2 did not work due to endpoints mistakenly being hardcoded