### PR TITLE
Bump major version to 3.0.0

### DIFF
--- a/lib/synapse_pay_rest/version.rb
+++ b/lib/synapse_pay_rest/version.rb
@@ -1,4 +1,4 @@
 module SynapsePayRest
   # Gem version
-  VERSION = '2.3.0'.freeze
+  VERSION = '3.0.0'.freeze
 end


### PR DESCRIPTION
While there shouldn't be any breaking changes for library users, I am bumping
the major version because it is risky for production users to update prior to
API v3.1.1 being deployed to production.