### PR TITLE
Fix env vars usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Not all API endpoints are supported.
 
 There are significant changes but backwards compatibility has been mostly maintained by building on top of the base API wrapper. You can still use the previous classes but note the following changes:
 
-- `ArgumentError` will be raised for missing payloads or other required arguments, where `RuntimeError` was raised previously. 
+- `ArgumentError` will be raised for missing payloads or other required arguments, where `RuntimeError` was raised previously.
 - `development_mode` now defaults to true (gem previously defaulted to production).
 - KYC 1.0 methods for uploading documents have been deprecated. Please contact SynapsePay if you need to update to KYC 2.0.
 - API errors will now raise `SynapsePayRest::Error`s instead returning a JSON hash (and sometimes obfuscating the API error message).
@@ -43,15 +43,15 @@ $ gem install synapse_pay_rest
 
 ## Contributing
 
-For minor issues, just open a pull request. For larger changes or features, please email steven@synapsepay.com.Please document and test any public constants/methods. Open an issue or email steven@synapsepay.com if you have any questions.
+For minor issues, just open a pull request. For larger changes or features, please email steven@synapsepay.com. Please document and test any public constants/methods. Open an issue or email steven@synapsepay.com if you have any questions.
 
 ## Running the Test Suite
 
 Make sure these values are set as enviroment variables (using [dotenv](https://github.com/bkeepers/dotenv) for example):
 
 ```
-CLIENT_ID=your_sandbox_client_id
-CLIENT_SECRET=your_sandbox_client_secret
+TEST_CLIENT_ID=your_sandbox_client_id
+TEST_CLIENT_SECRET=your_sandbox_client_secret
 ```
 
 To run all tests, execute:

--- a/test/synapse_pay_rest/client_test.rb
+++ b/test/synapse_pay_rest/client_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class ClientTest < Minitest::Test
   def setup
     @options = {
-      client_id:        ENV.fetch('CLIENT_ID'),
-      client_secret:    ENV.fetch('CLIENT_SECRET'),
+      client_id:        ENV.fetch('TEST_CLIENT_ID'),
+      client_secret:    ENV.fetch('TEST_CLIENT_SECRET'),
       ip_address:       '127.0.0.1',
       fingerprint:      'test_fp',
       development_mode: true


### PR DESCRIPTION
I've been having trouble starting to develop with the gem with the first time today. This updates the env var names to be prefixed with "TEST_" in the instructions and in the client test which was failing since it was trying to use "CLIENT_ID" while all other tests use "TEST_CLIENT_ID", etc.

Note that #49 has the same documentation change to use the correct prefixed env var for testing.