### PR TITLE
Streamline setup for local development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+# For development in a console
+CLIENT_ID=your_sandbox_client_id
+CLIENT_SECRET=your_sandbox_client_secret
+FINGERPRINT=your_sandbox_fingerprint
+
+# For running tests
+TEST_CLIENT_ID=your_sandbox_client_id
+TEST_CLIENT_SECRET=your_sandbox_client_secret

--- a/README.md
+++ b/README.md
@@ -47,12 +47,7 @@ For minor issues, just open a pull request. For larger changes or features, plea
 
 ## Running the Test Suite
 
-Make sure these values are set as enviroment variables (using [dotenv](https://github.com/bkeepers/dotenv) for example):
-
-```
-TEST_CLIENT_ID=your_sandbox_client_id
-TEST_CLIENT_SECRET=your_sandbox_client_secret
-```
+If you haven't already, run `cp .env.sample .env` and set the `TEST_CLIENT_ID` and `TEST_CLIENT_SECRET` environment variables.
 
 To run all tests, execute:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To run all tests, execute:
 rake
 ```
 
-To run a specific file or test, install the [m](https://github.com/qrush/m) gem and execute:
+To run a specific file or test run:
 
 ```bash
 m path/to/file:line_number

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "synapse_pay_rest"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'dotenv'
+Dotenv.load
+
+require "irb"
+IRB.start

--- a/samples.md
+++ b/samples.md
@@ -1,8 +1,16 @@
+# Setup
+
+First, run `cp .env.sample .env` if you haven't already and make sure `CLIENT_ID`, `CLIENT_SECRET`, and `FINGERPRINT` are set.
+
+Start a console that will load this gem and your settings from `.env` automatically.
+
+```
+$ ./bin/console
+```
+
 ## Initialization
 
 ```ruby
-require 'synapse_pay_rest'
-
 args = {
   # synapse client_id
   client_id:        ENV.fetch('CLIENT_ID'),
@@ -272,7 +280,7 @@ base_doc = virtual_doc.base_document
 
 ## Node Methods
 
-#### All Nodes for a User 
+#### All Nodes for a User
 
 ##### a) User#nodes
 

--- a/synapse_pay_rest.gemspec
+++ b/synapse_pay_rest.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'dotenv', '~> 2.1.1'
   s.add_development_dependency 'faker', '~> 1.6.6'
   s.add_development_dependency 'simplecov', '~> 0.12.0'
+  s.add_development_dependency 'm', '~> 1.5.0'
 end


### PR DESCRIPTION
Again had some frustration setting this gem up for development as I'm looking to use it now since the KBA process is deprecated and being removed in March.

This streamlines development since dotenv is already a development dependency, embrace it across the board so someone new using the gem has less roadblocks to get started. With a `.env.sample` file we now have a single documented place where env vars are set. Also a console script makes it easier to load the gem and env settings.