### PR TITLE
Add idempotency key support for Transaction creation

### DIFF
--- a/lib/synapse_pay_rest/api/transactions.rb
+++ b/lib/synapse_pay_rest/api/transactions.rb
@@ -57,9 +57,9 @@ module SynapsePayRest
     # HTTP response from API
     # 
     # @return [Hash] API response
-    def create(user_id:, node_id:, payload:)
+    def create(user_id:, node_id:, payload:, idempotency_key: nil)
       path = create_transaction_path(user_id: user_id, node_id: node_id)
-      client.post(path, payload)
+      client.post(path, payload, idempotency_key: idempotency_key)
     end
 
     # Sends a PATCH request to /trans endpoint to update a transaction. 

--- a/lib/synapse_pay_rest/http_client.rb
+++ b/lib/synapse_pay_rest/http_client.rb
@@ -73,11 +73,17 @@ module SynapsePayRest
     # 
     # @param path [String]
     # @param payload [Hash]
-    # 
+    # @param idempotency_key [String] (optional) avoid accidentally performing the same operation twice
+    #
     # @raise [SynapsePayRest::Error] subclass depends on HTTP response
     # 
     # @return [Hash] API response
-    def post(path, payload)
+    def post(path, payload, **options)
+      headers = get_headers
+      if options[:idempotency_key]
+        headers = headers.merge({'X-SP-IDEMPOTENCY-KEY' => options[:idempotency_key]})
+      end
+
       response = with_error_handling { RestClient.post(full_url(path), payload.to_json, headers) }
       p 'RESPONSE:', JSON.parse(response) if @logging
       JSON.parse(response)

--- a/lib/synapse_pay_rest/models/node/base_node.rb
+++ b/lib/synapse_pay_rest/models/node/base_node.rb
@@ -219,7 +219,8 @@ module SynapsePayRest
     # @param fee_note [String] (optional)
     # @param fee_to_id [String] (optional) node id to which to send the fee
     # @param supp_id [String] (optional)
-    # 
+    # @param idempotency_key [String] (optional) avoid accidentally performing the same operation twice
+    #
     # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
     # 
     # @return [SynapsePayRest::Transaction]

--- a/lib/synapse_pay_rest/models/transaction/transaction.rb
+++ b/lib/synapse_pay_rest/models/transaction/transaction.rb
@@ -33,7 +33,8 @@ module SynapsePayRest
       # @param fee_to_id [String] (deprecated) node id to which to send the fee (must be SYNAPSE-US)
       # @param fee_note [String] (deprecated)
       # @param supp_id [String] (optional)
-      # 
+      # @param idempotency_key [String] (optional)
+      #
       # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
       # 
       # @return [SynapsePayRest::Transaction]
@@ -57,7 +58,8 @@ module SynapsePayRest
         response = node.user.client.trans.create(
           user_id: node.user.id,
           node_id: node.id,
-          payload: payload
+          payload: payload,
+          idempotency_key: options[:idempotency_key],
         )
         from_response(node, response)
       end

--- a/test/api/transactions_test.rb
+++ b/test/api/transactions_test.rb
@@ -35,6 +35,43 @@ class TransactionsTest < Minitest::Test
     assert_equal transaction_response['to']['id'], transaction_payload['to']['id']
   end
 
+  def test_transactions_create_with_idempotency_key
+    idempotency_key = Time.now.to_i
+    transaction_payload = {
+      'to' => {
+        'type' => 'SYNAPSE-US',
+        'id'   => @nodes.last['_id']
+      },
+      'amount' => {
+        'amount'   => 55,
+        'currency' => 'USD'
+      },
+      'extra' => {
+        'ip' => '192.168.0.1'
+      }
+    }
+    transaction_response = @client.trans.create(
+      user_id: @user['_id'],
+      node_id: @nodes.first['_id'],
+      payload: transaction_payload,
+      idempotency_key: idempotency_key,
+    )
+
+    refute_nil transaction_response['_id']
+    assert_equal transaction_response['to']['id'], transaction_payload['to']['id']
+
+    error = assert_raises(SynapsePayRest::Error) {
+      @client.trans.create(
+        user_id: @user['_id'],
+        node_id: @nodes.first['_id'],
+        payload: transaction_payload,
+        idempotency_key: idempotency_key,
+      )
+    }
+    assert_kind_of SynapsePayRest::Error::ClientError, error
+    assert error.message =~ /Idempotency key already used/i
+  end
+
   def test_transactions_get
     transactions_response = @client.trans.get(
       user_id: @user['_id'],

--- a/test/factories/transaction.rb
+++ b/test/factories/transaction.rb
@@ -10,7 +10,8 @@ def test_transaction_create_args(node:,
                                  fee_amount: nil,
                                  fee_note: nil,
                                  fee_to_id: nil,
-                                 fees: nil)
+                                 fees: nil,
+                                 idempotency_key: nil)
   {
     node: node,
     to_type: to_type,
@@ -24,11 +25,12 @@ def test_transaction_create_args(node:,
     fee_amount: fee_amount,
     fee_note: fee_note,
     fee_to_id: fee_to_id,
-    fees: fees
+    fees: fees,
+    idempotency_key: idempotency_key,
   }
 end
 
-def test_transaction(node:, to_type:, to_id:)
-    args = test_transaction_create_args(node: node, to_type: to_type, to_id: to_id)
+def test_transaction(node:, to_type:, to_id:, **options)
+    args = test_transaction_create_args(node: node, to_type: to_type, to_id: to_id, **options)
     SynapsePayRest::Transaction.create(args)
 end


### PR DESCRIPTION
This adds `**options` to the HTTPClient `post` method so we can pass an optional idempotency key that needs to be set as a request header if given. This is a critical change to have in place. There are passing tests for the two code paths that allow creation of transactions. I haven't added docs in all places but let me know if you want that and more importantly what message.