### PR TITLE
Fix a failing test and an invalid assertion

### DIFF
--- a/lib/synapse_pay_rest/models/transaction/transaction.rb
+++ b/lib/synapse_pay_rest/models/transaction/transaction.rb
@@ -213,7 +213,7 @@ module SynapsePayRest
         trans_id: id,
         payload: payload
       )
-      self.class.from_response(node, response['trans'])
+      self.class.from_response(node, response)
     end
 
     # Cancels this transaction if it has not already settled.

--- a/lib/synapse_pay_rest/models/transaction/transaction.rb
+++ b/lib/synapse_pay_rest/models/transaction/transaction.rb
@@ -213,7 +213,7 @@ module SynapsePayRest
         trans_id: id,
         payload: payload
       )
-      self.class.from_response(node, response)
+      self.class.from_response(node, response['trans'])
     end
 
     # Cancels this transaction if it has not already settled.

--- a/test/api/transactions_test.rb
+++ b/test/api/transactions_test.rb
@@ -70,8 +70,8 @@ class TransactionsTest < Minitest::Test
       trans_id: @transactions.first['_id'],
       payload: payload
     )
-    refute_nil update_response['trans']['_id']
-    note = update_response['trans']['recent_status']['note']
+    refute_nil update_response['_id']
+    note = update_response['recent_status']['note']
     assert_match /Show me what you got/, note
   end
 

--- a/test/api/transactions_test.rb
+++ b/test/api/transactions_test.rb
@@ -70,8 +70,8 @@ class TransactionsTest < Minitest::Test
       trans_id: @transactions.first['_id'],
       payload: payload
     )
-    refute_nil update_response['_id']
-    note = update_response['recent_status']['note']
+    refute_nil update_response['trans']['_id']
+    note = update_response['trans']['recent_status']['note']
     assert_match /Show me what you got/, note
   end
 

--- a/test/api/transactions_test.rb
+++ b/test/api/transactions_test.rb
@@ -41,8 +41,8 @@ class TransactionsTest < Minitest::Test
       node_id: @nodes.first['_id']
     )
 
-    assert transactions_response['error_code'], 0
-    assert transactions_response['http_code'], 200
+    assert_equal transactions_response['error_code'], '0'
+    assert_equal transactions_response['http_code'], '200'
     assert_operator transactions_response['trans_count'], :>, 0
   end
 


### PR DESCRIPTION
The `add_comment` was failing due to the data not being at the root level of the response. Its contained within the "trans" key as documented in: https://docs.synapsepay.com/docs/update-transaction.

The second issue is a false positive as a test was incorrectly written with `assert` when it should have been using `assert_equal`. It wasn't failing but I noticed when working on #53.