### PR TITLE
Disable oauth for methods returning multiple users

### DIFF
--- a/lib/synapse_pay_rest/error.rb
+++ b/lib/synapse_pay_rest/error.rb
@@ -112,7 +112,7 @@ module SynapsePayRest
     # @return [SynapsePayRest::Error]
     def initialize(message: '', code: nil, response: {})
       super(message)
-      @code = code
+      @code     = code
       @response = response
     end
   end

--- a/lib/synapse_pay_rest/models/user/user.rb
+++ b/lib/synapse_pay_rest/models/user/user.rb
@@ -88,6 +88,8 @@ module SynapsePayRest
       # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
       # 
       # @return [Array<SynapsePayRest::User>]
+      # 
+      # @note users created this way are not automatically OAuthed
       def all(client:, page: nil, per_page: nil, query: nil)
         raise ArgumentError, 'client must be a SynapsePayRest::Client' unless client.is_a?(Client)
         [page, per_page].each do |arg|
@@ -115,6 +117,8 @@ module SynapsePayRest
       # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
       # 
       # @return [Array<SynapsePayRest::User>]
+      # 
+      # @note users created this way are not automatically OAuthed
       def search(client:, query:, page: nil, per_page: nil)
         all(client: client, query: query, page: page, per_page: per_page)
       end
@@ -140,7 +144,7 @@ module SynapsePayRest
 
       # Constructs a user instance from a user response.
       # @note Do not call directly.
-      def from_response(client, response)
+      def from_response(client, response, oauth: true)
         user = self.new(
           client:            client,
           id:                response['_id'],
@@ -159,13 +163,14 @@ module SynapsePayRest
           base_documents = BaseDocument.from_response(user, response)
           user.base_documents = base_documents
         end
-        user.authenticate
+        oauth ? user.authenticate : user
       end
 
       # Calls from_response on each member of a response collection.
+      # @note users created this way are not automatically OAuthed
       def multiple_from_response(client, response)
         return [] if response.empty?
-        response.map { |user_data| from_response(client, user_data)}
+        response.map { |user_data| from_response(client, user_data, oauth: false)}
       end
     end
 

--- a/test/model/user_test.rb
+++ b/test/model/user_test.rb
@@ -11,6 +11,8 @@ class UserTest < Minitest::Test
     refute_nil user.id
     # confirm refresh token from API response saved
     refute_nil user.refresh_token
+    # oauthed
+    refute_empty user.client.http_client.config[:oauth_key]
   end
 
   def test_create_user_with_incomplete_info
@@ -65,6 +67,9 @@ class UserTest < Minitest::Test
   def test_all
     user_instances = SynapsePayRest::User.all(client: test_client)
     user_instance  = user_instances.first
+
+    # not oauthed
+    assert_empty user_instance.client.http_client.config[:oauth_key]
     assert_instance_of Array, user_instances
     assert_equal 20, user_instances.length
     assert_instance_of SynapsePayRest::User, user_instance


### PR DESCRIPTION
It is unlikely that all users fetched will actually need to be oauthed. This cuts down on unnecessary requests.