### PR TITLE
add oauth_key and expires_in to user model.

### DIFF
--- a/lib/synapse_pay_rest.rb
+++ b/lib/synapse_pay_rest.rb
@@ -6,6 +6,7 @@ require 'synapse_pay_rest/http_client'
 require 'synapse_pay_rest/api/users'
 require 'synapse_pay_rest/api/nodes'
 require 'synapse_pay_rest/api/transactions'
+require 'synapse_pay_rest/api/subscriptions'
 
 # general library classes
 require 'synapse_pay_rest/error'
@@ -51,6 +52,9 @@ require 'synapse_pay_rest/models/node/node'
 
 # transaction-related classes
 require 'synapse_pay_rest/models/transaction/transaction'
+
+# subscription-related classes
+require 'synapse_pay_rest/models/subscription/subscription'
 
 # Namespace for all SynapsePayRest classes and modules
 module SynapsePayRest

--- a/lib/synapse_pay_rest/api/subscriptions.rb
+++ b/lib/synapse_pay_rest/api/subscriptions.rb
@@ -48,7 +48,7 @@ module SynapsePayRest
     # @todo Probably should use CGI or RestClient's param builder instead of
     # rolling our own, probably error-prone and untested version
     # https://github.com/rest-client/rest-client#usage-raw-url
-    def get(subscription_id:, **options)
+    def get(subscription_id: nil, **options)
       path = subscription_path(subscription_id: subscription_id)
 
       params = VALID_QUERY_PARAMS.map do |p|
@@ -59,6 +59,22 @@ module SynapsePayRest
       client.get(path)
     end
 
+    # Sends a PATCH request to /subscriptions endpoint, updating the current subscription
+    # and returns the response.
+    # 
+    # @param payload [Hash]
+    # @see https://docs.synapsepay.com/docs/update-subscription payload structure for
+    #   updating subscription
+    # 
+    # @raise [SynapsePayRest::Error] may return subclasses of error based on 
+    # HTTP response from API
+    # 
+    # @return [Hash] API response
+    def update(subscription_id:, payload:)
+      path = subscription_path(subscription_id: subscription_id)
+      client.patch(path, payload)
+    end
+    
     private
 
     def subscription_path(subscription_id: nil)

--- a/lib/synapse_pay_rest/api/subscriptions.rb
+++ b/lib/synapse_pay_rest/api/subscriptions.rb
@@ -1,0 +1,71 @@
+module SynapsePayRest
+  # Wrapper class for /subscriptions endpoints
+  # 
+  # @todo Implement idempotency keys
+  class Subscriptions
+
+    # Valid optional args for #get
+    # @todo Refactor to HTTPClient
+    VALID_QUERY_PARAMS = [:page, :per_page].freeze
+
+    # @!attribute [rw] client
+    #   @return [SynapsePayRest::HTTPClient]
+    attr_accessor :client
+
+    # @param client [SynapsePayRest::HTTPClient]
+    def initialize(client)
+      @client = client
+    end
+
+    # Sends a POST request to /subscriptions endpoint to create a new subscription.
+    # Returns the response.
+    # 
+    # @param url [String]
+    # @param scope [Array]
+    # @see https://docs.synapsepay.com/docs/create-subscription payload structure
+    # 
+    # @raise [SynapsePayRest::Error] may return subclasses of error based on 
+    # HTTP response from API
+    # 
+    # @return [Hash] API response
+    def create(payload:)
+      path = subscription_path
+      client.post(path, payload)
+    end
+
+    # Sends a GET request to /subscriptions endpoint. Queries a specific subscription_id
+    # if subs_id supplied, else queries all subscriptions. Returns the response.
+    # 
+    # @param subscription_id [String,void] (optional) id of a subscription to look up
+    # @param page [String,Integer] (optional) response will default to 1
+    # @param per_page [String,Integer] (optional) response will default to 20
+    # 
+    # @raise [SynapsePayRest::Error] may return subclasses of error based on 
+    # HTTP response from API
+    # 
+    # @return [Hash] API response
+    # 
+    # @todo Probably should use CGI or RestClient's param builder instead of
+    # rolling our own, probably error-prone and untested version
+    # https://github.com/rest-client/rest-client#usage-raw-url
+    def get(subscription_id:, **options)
+      path = subscription_path(subscription_id: subscription_id)
+
+      params = VALID_QUERY_PARAMS.map do |p|
+        options[p] ? "#{p}=#{options[p]}" : nil
+      end.compact
+
+      path += '?' + params.join('&') if params.any?
+      client.get(path)
+    end
+
+    private
+
+    def subscription_path(subscription_id: nil)
+      path = "/subscriptions"
+      path += "/#{subscription_id}" if subscription_id
+      path
+    end
+
+  end
+end

--- a/lib/synapse_pay_rest/client.rb
+++ b/lib/synapse_pay_rest/client.rb
@@ -11,7 +11,9 @@ module SynapsePayRest
     #   @return [SynapsePayRest::Nodes]
     # @!attribute [rw] transactions
     #   @return [SynapsePayRest::Transactions]
-    attr_accessor :http_client, :users, :nodes, :transactions
+    # @!attribute [rw] subscriptions
+    #   @return [SynapsePayRest::Subscriptions]
+    attr_accessor :http_client, :users, :nodes, :transactions, :subscriptions
 
     # Alias for #transactions (legacy name)
     alias_method :trans, :transactions
@@ -39,9 +41,10 @@ module SynapsePayRest
                                      fingerprint: fingerprint,
                                      ip_address: ip_address,
                                      **options)
-      @users        = Users.new @http_client
-      @nodes        = Nodes.new @http_client
-      @transactions = Transactions.new @http_client
+      @users         = Users.new @http_client
+      @nodes         = Nodes.new @http_client
+      @transactions  = Transactions.new @http_client
+      @subscriptions = Subscriptions.new @http_client
     end
   end
 end

--- a/lib/synapse_pay_rest/models/subscription/subscription.rb
+++ b/lib/synapse_pay_rest/models/subscription/subscription.rb
@@ -1,0 +1,77 @@
+module SynapsePayRest
+  # Represents a subscription record and holds methods for creating subsription instances
+  # from API calls. This is built on top of the SynapsePayRest::Subscription class and
+  # is intended to make it easier to use the API without knowing payload formats
+  # or knowledge of REST.
+  # 
+  # @todo use mixins to remove duplication between Node and BaseNode.
+  class Subscription
+    attr_reader :id, :is_active, :scope, :url
+
+    class << self
+      # Creates a new subscription in the API and returns a Subscription instance from the
+      # response data.
+      # 
+      # @param client [SynapsePayRest::Client]
+      # @param scope [Array<String>]
+      # @param url [String]
+      # 
+      # @raise [SynapsePayRest::Error] if HTTP error or invalid argument format
+      # 
+      # @return [SynapsePayRest::Subscription]
+      def create(client:, url:, scope:, **options)
+        raise ArgumentError, 'client must be a SynapsePayRest::Client' unless client.is_a?(Client)
+        
+        payload = payload_for_create(url: url, scope: scope, **options)
+        response = client.subscriptions.create(payload: payload)
+        from_response(response)
+      end
+
+      # Creates a Subscription from a response hash.
+      # 
+      # @note Shouldn't need to call this directly.
+      def from_response(response)
+        args = {
+          id:            response['_id'],
+          is_active:     response['is_active'],
+          scope:         response['scope'],
+          url:           response['url']
+        }
+        self.new(args)
+      end
+
+      private
+
+      # Converts #create args into API payload structure.
+      def payload_for_create(**options)
+        payload = {}
+        # must have one of these
+        payload['url']       = options[:url] if options[:url]
+        payload['scope']     = options[:scope] if options[:scope]
+        payload
+      end
+
+      # Converts #update args into API payload structure.
+      def payload_for_update(**options)
+        payload = {}
+        # must have one of these
+        payload['is_active'] = options[:is_active] if options[:is_active]
+        payload['url']       = options[:url] if options[:url]
+        payload['scope']     = options[:scope] if options[:scope]
+        payload
+      end
+
+    end
+
+    # @note Do not call directly. Use Subscription.create or other class method
+    #   to instantiate via API action.
+    def initialize(**options)
+      options.each { |key, value| instance_variable_set("@#{key}", value) }
+    end
+
+    # Checks if two Subscription instances have same id (different instances of same record).
+    def ==(other)
+      other.instance_of?(self.class) && !id.nil? && id == other.id
+    end
+  end
+end

--- a/lib/synapse_pay_rest/models/user/user.rb
+++ b/lib/synapse_pay_rest/models/user/user.rb
@@ -13,7 +13,7 @@ module SynapsePayRest
     #   @return [String] https://docs.synapsepay.com/docs/user-resources#section-user-permissions
     attr_reader :client, :id, :logins, :phone_numbers, :legal_names, :note, 
                 :supp_id, :is_business, :cip_tag, :permission
-    attr_accessor :refresh_token, :base_documents
+    attr_accessor :refresh_token, :base_documents, :oauth_key, :expires_in
 
     class << self
       # Creates a new user in the API and returns a User instance from the
@@ -186,9 +186,11 @@ module SynapsePayRest
     # 
     # @raise [SynapsePayRest::Error]
     # 
-    # @return [SynapsePayRest::User] (self)
+    # @return [SynapsePayRest::User] (new instance with updated tokens)
     def authenticate
-      client.users.refresh(user_id: id, payload: payload_for_refresh)
+      response        = client.users.refresh(user_id: id, payload: payload_for_refresh)
+      self.oauth_key  = response['oauth_key']
+      self.expires_in = response['expires_in']
       self
     end
 

--- a/test/api/subscriptions_test.rb
+++ b/test/api/subscriptions_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class SubscriptionsTest < Minitest::Test
+  def setup
+    test_values   = test_client_with_one_subscription
+    @client       = test_values[:client]
+    @subscription = test_values[:subscription]
+  end
+
+  def test_subscriptions_create
+    subscription_payload = {
+      'url' => "http://localhost:3000",
+      'scope' => ['USERS|POST']
+    }
+    subscription_response = @client.subscriptions.create(
+      payload: subscription_payload
+    )
+
+    refute_nil subscription_response['_id']
+    assert_equal subscription_response['is_active'], true
+    assert_equal subscription_response['scope'], subscription_payload['scope']
+    assert_equal subscription_response['url'], subscription_payload['url']
+  end
+
+  def test_subscriptions_get
+    subscriptions_response = @client.subscriptions.get()
+
+    assert_equal '0', subscriptions_response['error_code']
+    assert_equal '200', subscriptions_response['http_code']
+    assert_operator subscriptions_response['subscriptions_count'], :>, 0
+  end
+
+  def test_subscriptions_get_with_subscription_id
+    subscriptions_response = @client.subscriptions.get(
+      subscription_id: @subscription['_id']
+    )
+    subscription_id = subscriptions_response['_id']
+    
+    assert_equal subscription_id, @subscription['_id']
+  end
+
+  def test_subscriptions_update
+    payload = {'url' => "http://test.com.update"}
+    
+    update_response = @client.subscriptions.update(
+      subscription_id: @subscription['_id'],
+      payload: payload
+    )
+    refute_nil update_response['_id']
+    is_active = update_response['url']
+    assert_match "http://test.com.update", is_active
+  end
+
+end

--- a/test/factories/client.rb
+++ b/test/factories/client.rb
@@ -83,3 +83,10 @@ def test_client_with_two_transactions
   )
   {client: client, user: user, nodes: nodes, transactions: [trans1, trans2]}
 end
+
+def test_client_with_one_subscription
+  client = test_client
+  payload  = test_subscription_payload
+  subscription = client.subscriptions.create(payload: payload)
+  {client: client, subscription: subscription}
+end

--- a/test/factories/subscription.rb
+++ b/test/factories/subscription.rb
@@ -1,0 +1,11 @@
+def test_subscription_create_args(url:, scope:)
+  {
+    url: url,
+    scope: scope
+  }
+end
+
+def test_subscription(url:, scope:, **options)
+    args = test_subscription_create_args(url: url, scope: scope, **options)
+    SynapsePayRest::Subscription.create(args)
+end

--- a/test/factories/subscriptions_payloads.rb
+++ b/test/factories/subscriptions_payloads.rb
@@ -1,0 +1,7 @@
+# create different number of subscription for different tests
+def test_subscription_payload(url: "http://localhost:3000", scope: ['USERS|POST'])
+  {
+    'url' => url,
+    'scope' => scope
+  }
+end


### PR DESCRIPTION
When interacting with the API we require the oauth_key,
currently the `authenticate` method was not updating this
inside the user model, only the refresh token.

Is this something that could be added to the gem? If not 
please let me know what is the best solution for this.