### PR TITLE
Add ssl_cert_store option when initializing

### DIFF
--- a/lib/synapse_pay_rest/http_client.rb
+++ b/lib/synapse_pay_rest/http_client.rb
@@ -14,6 +14,9 @@ module SynapsePayRest
     #   @return [String] the url which is used to proxy outboard requests
     attr_reader :proxy_url
 
+    # @!attribute [rw] ssl_cert_store
+    #   @return [OpenSSL::X509::Store] the customized CA cert store
+
     # @param base_url [String] the base url of the API (production or sandbox)
     # @param client_id [String]
     # @param client_secret [String]
@@ -22,6 +25,7 @@ module SynapsePayRest
     # @param logging [Boolean] (optional) logs to stdout when true
     # @param log_to [String] (optional) file path to log to file (logging must be true)
     # @param proxy_url [String] (optional) proxy url which is used to proxy outbound requests
+    # @param ssl_cert_store [OpenSSL::X509::Store] (optional) a custom store of allowed CA certs
     def initialize(base_url:, client_id:, fingerprint:, ip_address:,
                    client_secret:, **options)
       log_to         = options[:log_to] || 'stdout'
@@ -30,6 +34,9 @@ module SynapsePayRest
 
       RestClient.proxy = options[:proxy_url] if options[:proxy_url]
       @proxy_url = options[:proxy_url]
+
+      RestClient.ssl_cert_store = options[:ssl_cert_store] if options[:ssl_cert_store]
+      @ssl_cert_store = options[:ssl_cert_store]
 
       @config = {
         client_id:     client_id,

--- a/samples.md
+++ b/samples.md
@@ -25,9 +25,11 @@ args = {
   # (optional) if true logs requests to stdout
   logging:          true,
   # (optional) file path to write logs to
-  log_to:           nil
+  log_to:           nil,
   # (optional) URL used to proxy outbound requests
-  proxy_url:        nil
+  proxy_url:        nil,
+  # (optional) a [OpenSSL::X509::Store](https://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/X509/Store.html) of allowed CA certs
+  ssl_cert_store:   nil,
 }
 
 client = SynapsePayRest::Client.new(args)

--- a/test/factories/client.rb
+++ b/test/factories/client.rb
@@ -5,7 +5,8 @@ def test_client(client_id: ENV.fetch('TEST_CLIENT_ID'),
                 development_mode: true,
                 logging: false,
                 log_to: nil,
-                proxy_url: nil)
+                proxy_url: nil,
+                ssl_cert_store: nil)
 
   SynapsePayRest::Client.new(
     client_id: client_id,
@@ -15,7 +16,8 @@ def test_client(client_id: ENV.fetch('TEST_CLIENT_ID'),
     ip_address: ip_address,
     logging: logging,
     log_to: log_to,
-    proxy_url: proxy_url
+    proxy_url: proxy_url,
+    ssl_cert_store: ssl_cert_store
   )
 end
 

--- a/test/synapse_pay_rest/http_client_test.rb
+++ b/test/synapse_pay_rest/http_client_test.rb
@@ -8,6 +8,7 @@ class HTTPClientTest < Minitest::Test
 
   def teardown
     RestClient.proxy = nil
+    RestClient.ssl_cert_store = nil
   end
 
   def test_base_url
@@ -56,5 +57,18 @@ class HTTPClientTest < Minitest::Test
     client_with_proxy = test_client(proxy_url: proxy_url)
     assert_equal client_with_proxy.http_client.proxy_url, proxy_url
     assert_equal RestClient.proxy, proxy_url
+  end
+
+  def test_ssl_cert_store
+    cert_store = OpenSSL::X509::Store.new
+    cert_store.set_default_paths
+
+    client_without_store = test_client
+    assert_nil client_without_store.http_client.ssl_cert_store
+    assert_nil RestClient.ssl_cert_store
+
+    client_with_store = test_client(ssl_cert_store: cert_store)
+    assert_equal client_with_store.http_client.ssl_cert_store, cert_store
+    assert_equal RestClient.ssl_cert_store, cert_store
   end
 end


### PR DESCRIPTION
This PR allows setting a custom CA cert store for RestClient on initialization.

More info on the restclient option: https://github.com/rest-client/rest-client#ssltls-support
More info on the store object: https://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/X509/Store.html