### PR TITLE
Update samples.md

### DIFF
--- a/samples.md
+++ b/samples.md
@@ -25,7 +25,7 @@ args = {
   # (optional) if true logs requests to stdout
   logging:          true,
   # (optional) file path to write logs to
-  log_to:           nil
+  log_to:           nil,
   # (optional) URL used to proxy outbound requests
   proxy_url:        nil
 }


### PR DESCRIPTION
Initialization example fails due to missing comma with error:

robpetty@Robs-MacBook-Pro RubyWrapperTest % ruby wrapper-test.rb
wrapper-test.rb:17: syntax error, unexpected tIDENTIFIER, expecting '}'
    proxy_url:        nil